### PR TITLE
Fix assembling disassembled files failing

### DIFF
--- a/pga-lib/src/main/java/com/guardsquare/proguard/assembler/AssemblyConstants.java
+++ b/pga-lib/src/main/java/com/guardsquare/proguard/assembler/AssemblyConstants.java
@@ -36,14 +36,14 @@ public final class AssemblyConstants
 
     public static final String ACC_ANNOTATION = "annotation";
 
-    public static final String TYPE_STRING        = "String";
-    public static final String TYPE_CLASS         = "Class";
-    public static final String TYPE_METHOD_HANDLE = "MethodHandle";
-    public static final String TYPE_METHOD_TYPE   = "MethodType";
+    public static final String TYPE_STRING        = "java.lang.String";
+    public static final String TYPE_CLASS         = "java.lang.Class";
+    public static final String TYPE_METHOD_HANDLE = "java.lang.invoke.MethodHandle";
+    public static final String TYPE_METHOD_TYPE   = "java.lang.invoke.MethodType";
     public static final String TYPE_DYNAMIC       = "Dynamic";
-    public static final String TYPE_ANNOTATION    = "Annotation";
-    public static final String TYPE_ENUM          = "Enum";
-    public static final String TYPE_ARRAY         = "Array";
+    public static final String TYPE_ANNOTATION    = "java.lang.Annotation";
+    public static final String TYPE_ENUM          = "java.lang.Enum";
+    public static final String TYPE_ARRAY         = "java.lang.reflect.Array";
     public static final String TYPE_DOUBLE        = "D";
     public static final String TYPE_FLOAT         = "F";
     public static final String TYPE_LONG          = "L";


### PR DESCRIPTION
I noticed that a file disassembled with Proguard Assembler cannot be assembled again, it results in a `ParseException`. I tried tracing the source of this issue and it appears to be that the disassembler outputs fully qualified types for some things while the parser does not. An example of this is the switch case at line 570 of `pga-lib/src/main/java/com/guardsquare/proguard/assembler/Parser.java`, it makes use of `AssemblyConstants.TYPE_METHOD_HANDLE` which is defined as just `"MethodHandle"`.

This PR attempts to resolve the issues that come from trying to reassemble files first disassembled using the disassembler by adjusting some of these constants to use the fully qualified names.