### PR TITLE
Update proguard-core to version 9.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ target = 1.8
 
 kotlinVersion = 1.9.0
 kotestVersion = 5.6.2
-proguardCoreVersion = 9.0.9
+proguardCoreVersion = 9.1.0


### PR DESCRIPTION
The newer version fixes some of the dependency issues that prevented me from writing tests using Kotlin or Java snippets. This will be useful to make the tests work on the fixes to the constants pr #13.