### PR TITLE
Fix copyBuild dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can download the assembler and disassembler in various forms:
 
 If you've downloaded the source code, you can build it with Gradle:
 
-    ./gradlew clean assemble
+    ./gradlew clean build
 
 Once built, you can [run the assembler and disassembler](index.md) with the
 script `bin/assembler.sh` or `bin/assembler.bat`.

--- a/pga-cli/build.gradle
+++ b/pga-cli/build.gradle
@@ -34,11 +34,12 @@ jar {
 
 tasks.register('copyBuild', Copy) {
     dependsOn tasks.jar
-    tasks.assemble.dependsOn(it)
 
     from tasks.jar.outputs
     into file("$rootDir/lib")
 }
+
+tasks.named("build") { finalizedBy("copyBuild") }
 
 distributions {
     main {


### PR DESCRIPTION
Ensure that copyBuild is run after build to copy the jar into the lib/ directory.
The scripts in bin/ assume the jar is in this directory.
